### PR TITLE
Fix missmatching quote

### DIFF
--- a/www/assets/blockly/fs_blocks_lua.js
+++ b/www/assets/blockly/fs_blocks_lua.js
@@ -118,8 +118,8 @@ Blockly.Lua.fsSessionRead = function(block) {
   }
 
   var code = variable_digits + ' = session:read(' + text_min + ', ' +
-    text_max + ', "' +
-    text_sound + '", ' +
+    text_max + ', ' +
+    text_sound + ', ' +
     text_timeout + ', "' +
     text_terminator + '");\n';
   return code;


### PR DESCRIPTION
This pull request fix the following issue:
https://github.com/seven1240/xui/issues/24

The "(" ")" has been changed to (" ").